### PR TITLE
[UPD] Always use https

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2,7 +2,7 @@
 
 set -e
 
-LIBRARIES_REPOSITORIES='git@github.com:sunflowerit/waftlib.git'
+LIBRARIES_REPOSITORIES='https://github.com/sunflowerit/waftlib.git'
 LIBRARIES_BRANCH='master'
 
 ################################################################


### PR DESCRIPTION
Current version gives error message if you don't have an ssh key that can connect with github